### PR TITLE
In docs remove Object as a supported data type for websocket.send

### DIFF
--- a/doc/ws.md
+++ b/doc/ws.md
@@ -553,7 +553,7 @@ only removes listeners added with
 
 ### websocket.send(data[, options][, callback])
 
-- `data` {Array|Number|Object|String|ArrayBuffer|Buffer|DataView|TypedArray} The
+- `data` {Array|Number|String|ArrayBuffer|Buffer|DataView|TypedArray} The
   data to send.
 - `options` {Object}
   - `binary` {Boolean} Specifies whether `data` should be sent as a binary or


### PR DESCRIPTION
The websocket.send function does not support a plain old Object of any shape and throws a TypeError.

Docs claim it is supported.

This fixes the docs.
